### PR TITLE
Update of readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ python3
 Python 3.4.0 (default, Apr 11 2014, 13:05:11) 
 [GCC 4.8.2] on linux
 Type "help", "copyright", "credits" or "license" for more information.
->>> from amazon-pay.client import AmazonPayClient
+>>> from amazon_pay.client import AmazonPayClient
 >>> 
 ```
 


### PR DESCRIPTION
Should be an underscore in >>> amazon_pay.client not a hyphen.